### PR TITLE
Update api

### DIFF
--- a/main.py
+++ b/main.py
@@ -76,7 +76,7 @@ class Scheduler:
 """TouchGal API接口封装"""
 class TouchGalAPI:
     def __init__(self):
-        self.base_url = "https://www.touchgal.us/api"
+        self.base_url = "https://www.touchgal.top/api"
         self.search_url = f"{self.base_url}/search"
         self.download_url = f"{self.base_url}/patch/resource"
         self.temp_dir = StarTools.get_data_dir("astrbot_plugin_touchgal") / "tmp"


### PR DESCRIPTION
修复`API 请求错误：API 返回了无效的 JSON 数据`问题
将 API 地址同步更换后解决

> 参考：[TouchGal·域名更换通知](https://www.touchgal.top/doc/notice/domainus)